### PR TITLE
Move up gdax/version.rb in require to avoid error

### DIFF
--- a/lib/gdax.rb
+++ b/lib/gdax.rb
@@ -8,6 +8,8 @@ require 'openssl'
 
 require 'faraday'
 
+require 'gdax/version'
+
 require 'gdax/errors'
 
 require 'gdax/client/verbs'
@@ -40,8 +42,6 @@ require 'gdax/product'
 require 'gdax/position'
 require 'gdax/report'
 require 'gdax/withdrawal'
-
-require 'gdax/version'
 
 ##
 # A Ruby client to GDAX REST API


### PR DESCRIPTION
Fixes:
```
lib/gdax/client.rb:14:in `<class:Client>': uninitialized constant GDAX::VERSION (NameError)
```